### PR TITLE
Fix CD streaming and analog pad SDK behavior

### DIFF
--- a/RecompOne.Runtime/sdk/LibCd.cs
+++ b/RecompOne.Runtime/sdk/LibCd.cs
@@ -131,6 +131,12 @@ public static class LibCd
     internal static int CurrentLba { get { lock (_posGate) return PosToInt(_pos); } }
     internal static double SectorsPerSecond => (_mode & 0x80) != 0 ? 150.0 : 75.0; //cd pacer
 
+    internal static void SetStreamLba(int lba)
+    {
+        lock (_posGate)
+            IntToPos(lba, out _pos[0], out _pos[1], out _pos[2]);
+    }
+
     internal static void Tick()
     {
         bool xaMode = (_mode & 0x40) != 0;
@@ -145,12 +151,14 @@ public static class LibCd
         var snap = c.Snapshot();
         while (_cbData != 0)
         {
+            Dispatcher.LoadByLba(CurrentLba);
             _lastIntr = DataReady;
             if (_cbReady != 0) { c.A0 = DataReady; c.A1 = 0; Dispatcher.Call(c, m, _cbReady); }
-            AdvancePos(1);
-            Dispatcher.LoadByLba(CurrentLba);
             if (_cbData != 0) { c.A0 = DataReady; c.A1 = 0; Dispatcher.Call(c, m, _cbData); }
+            AdvancePos(1);
         }
+        _lastIntr = Complete;
+        _readActive = false;
         c.Restore(snap);
     }
 
@@ -210,6 +218,7 @@ public static class LibCd
     {
         uint madr = c.A0;
         int words = (int)c.A1;
+        if (words == 0) words = 512;
         int lba = CurrentLba;
         byte[] data;
         lock (DiscLock) data = Runtime.Cd!.ReadSectorData(lba);
@@ -254,8 +263,19 @@ public static class LibCd
 
     public static void CdSyncCallback(CpuContext c, IMemory m) { c.V0 = _cbSync; _cbSync = c.A0; }
     public static void CdReadyCallback(CpuContext c, IMemory m) { c.V0 = _cbReady; _cbReady = c.A0; }
-    public static void CdReadCallback(CpuContext c, IMemory m) { c.V0 = _cbData; _cbData = c.A0; }
-    public static void CdDataCallback(CpuContext c, IMemory m) { c.V0 = _cbData; _cbData = c.A0; }
+    public static void CdReadCallback(CpuContext c, IMemory m)
+    {
+        c.V0 = _cbData;
+        _cbData = c.A0;
+    }
+
+    public static void CdDataCallback(CpuContext c, IMemory m)
+    {
+        c.V0 = _cbData;
+        _cbData = c.A0;
+    }
+
+    public static void Poll(CpuContext c, IMemory m) => Tick();
 
     public static void CdStatus(CpuContext c, IMemory m) => c.V0 = _status;
     public static void CdMode(CpuContext c, IMemory m) => c.V0 = _mode;
@@ -344,9 +364,13 @@ public static class LibCd
                     return DiskError;
                 }
                 _xaActive = true;
-                _readActive = false;
+                // ReadS is also used for standalone XA playback.  Without an
+                // STR ring there is no LibCdStream worker, so the normal XA
+                // pump must advance the disc and feed the decoder.
+                _readActive = !LibCdStream.InUse;
                 _status = (byte)(StatMotor | StatRead);
                 LibCdStream.OnReadStream(CurrentLba);
+                if (_readActive) EnsureXaThread();
                 break;
             case Play:
                 _readActive = false;

--- a/RecompOne.Runtime/sdk/LibCdStream.cs
+++ b/RecompOne.Runtime/sdk/LibCdStream.cs
@@ -108,6 +108,7 @@ public static class LibCdStream
     {
         if (!InUse) return;
         _pendingLba = lba;
+        _streamLba = -1;
         _reading = true;
         EnsureThread();
     }
@@ -152,20 +153,41 @@ public static class LibCdStream
             {
                 _streamLba = _pendingLba >= 0 ? _pendingLba : LibCd.CurrentLba;
                 _streamStartLba = _streamLba;
+                LibCd.SetStreamLba(_streamLba);
                 _clock.Restart();
+            }
+
+            // ReadS advances at the physical drive rate.  In particular, XA
+            // sectors must not be decoded as quickly as the host can read them:
+            // the game polls GetlocP to decide when a stream has ended.
+            double delivered = _clock.Elapsed.TotalSeconds * LibCd.SectorsPerSecond;
+            if ((_streamLba - _streamStartLba) + 1 > delivered)
+            {
+                Thread.Sleep(1);
+                continue;
             }
 
             byte[] sec;
             try { lock (LibCd.DiscLock) sec = cd.ReadSectorData(_streamLba, 2336); }
             catch { Thread.Sleep(2); continue; }
 
-            if ((sec[2] & 0x04) != 0) { XaAudio.DecodeSector(sec, 8, sec[3]); _streamLba++; continue; }
-            if (Read16(sec, 8) != VideoMagic || Read16(sec, 12) != 0) { _streamLba++; continue; }
+            if ((sec[2] & 0x04) != 0)
+            {
+                XaAudio.DecodeSector(sec, 8, sec[3]);
+                _streamLba++;
+                LibCd.SetStreamLba(_streamLba);
+                continue;
+            }
+            if (Read16(sec, 8) != VideoMagic || Read16(sec, 12) != 0)
+            {
+                _streamLba++;
+                LibCd.SetStreamLba(_streamLba);
+                continue;
+            }
 
             int n = Read16(sec, 14);
             if (n <= 0 || n > _slots) { _streamLba++; continue; }
 
-            double delivered = _clock.Elapsed.TotalSeconds * LibCd.SectorsPerSecond;
             if ((_streamLba - _streamStartLba) + n > delivered) { Thread.Sleep(1); continue; }
 
             int start;
@@ -210,6 +232,7 @@ public static class LibCdStream
             collected++;
         }
         _streamLba = lba;
+        LibCd.SetStreamLba(_streamLba);
         Thread.MemoryBarrier();
         return true;
     }

--- a/RecompOne.Runtime/sdk/LibPad.cs
+++ b/RecompOne.Runtime/sdk/LibPad.cs
@@ -9,13 +9,21 @@ public static class LibPad
     const byte Connected = 0x00;
     const byte Disconnected = 0xFF;
     const byte DigitalId = 0x41;
+    const byte AnalogId = 0x73;
     const uint PadStateDiscon = 0;
     const uint PadStateStable = 6;
+
+    const uint InfoModeCurId = 1;
+    const uint InfoModeCurExId = 2;
+    const uint InfoModeCurExOffs = 3;
+    const uint InfoModeIdTable = 4;
 
     static uint _buf1;
     static uint _buf2;
     static int _smallMotorIdx = 0;
     static int _largeMotorIdx = 1;
+    static bool _analog1 = true;
+    static bool _analog2 = true;
 
     public static void PadInitDirect(CpuContext c, IMemory m)
     {
@@ -36,23 +44,70 @@ public static class LibPad
     public static void PadGetState(CpuContext c, IMemory m)
         => c.V0 = IsPort1(c.A0) || Controller.Connected2 ? PadStateStable : PadStateDiscon;
 
-    public static void PadInfoMode(CpuContext c, IMemory m) => c.V0 = 0;
-    public static void PadInfoComb(CpuContext c, IMemory m) => c.V0 = 0;
+    public static void PadInfoMode(CpuContext c, IMemory m)
+    {
+        bool analog = IsPort1(c.A0) ? _analog1 : _analog2;
+        c.V0 = c.A1 switch
+        {
+            InfoModeCurId => analog ? 7u : 4u,
+            InfoModeCurExId => analog ? 7u : 0u,
+            InfoModeCurExOffs => 1u,
+            InfoModeIdTable when c.A2 == uint.MaxValue => 2u,
+            InfoModeIdTable when c.A2 == 0 => 4u,
+            InfoModeIdTable when c.A2 == 1 => 7u,
+            _ => 0u,
+        };
+    }
+    public static void PadInfoComb(CpuContext c, IMemory m)
+    {
+        c.V0 = (int)c.A1 switch
+        {
+            < 0 => 1u,
+            0 when (int)c.A2 < 0 => 2u,
+            0 when c.A2 < 2 => c.A2,
+            _ => 0u,
+        };
+    }
 
     public static void PadInfoAct(CpuContext c, IMemory m)
     {
-        c.V0 = (int)c.A2 < 0 ? 2u : 1u;
+        int actuator = (int)c.A1;
+        if (actuator < 0)
+        {
+            c.V0 = 2;
+            return;
+        }
+
+        if (actuator > 1)
+        {
+            c.V0 = 0;
+            return;
+        }
+
+        c.V0 = c.A2 switch
+        {
+            1 => 1u,
+            2 => (uint)(actuator + 1),
+            3 => (uint)actuator,
+            4 => actuator == 0 ? 20u : 40u,
+            5 => 0u,
+            _ => 0u,
+        };
     }
 
-    public static void PadSetMainMode(CpuContext c, IMemory m) { c.V0 = 0; }
+    public static void PadSetMainMode(CpuContext c, IMemory m)
+    {
+        if (IsPort1(c.A0)) _analog1 = c.A1 != 0;
+        else _analog2 = c.A1 != 0;
+        c.V0 = 1;
+    }
 
     public static void PadSetActAlign(CpuContext c, IMemory m)
     {
         if (!IsPort1(c.A0)) { c.V0 = 1; return; }
         uint ptr = c.A1;
-        uint len = c.A2;
-        if (ptr == 0 || len < 2) { c.V0 = 0; return; }
-        for (int i = 0; i < (int)len && i < 6; i++)
+        if (ptr == 0) { c.V0 = 0; return; }
+        for (int i = 0; i < 6; i++)
         {
             byte v = m.ReadU8(ptr + (uint)i);
             if (v == 0x00) _smallMotorIdx = i;
@@ -75,18 +130,19 @@ public static class LibPad
 
     public static void Refresh(IMemory m)
     {
-        if (_buf1 != 0) WritePad(m, _buf1, Controller.State, true,
+        if (_buf1 != 0) WritePad(m, _buf1, Controller.State, true, _analog1,
             Controller.RightX, Controller.RightY, Controller.LeftX, Controller.LeftY);
-        if (_buf2 != 0) WritePad(m, _buf2, Controller.State2, Controller.Connected2,
+        if (_buf2 != 0) WritePad(m, _buf2, Controller.State2, Controller.Connected2, _analog2,
             Controller.RightX2, Controller.RightY2, Controller.LeftX2, Controller.LeftY2);
     }
 
     static bool IsPort1(uint port) => (port & 0x10u) == 0;
 
-    static void WritePad(IMemory m, uint buf, ushort buttons, bool present, byte rx, byte ry, byte lx, byte ly)
+    static void WritePad(IMemory m, uint buf, ushort buttons, bool present, bool analog,
+        byte rx, byte ry, byte lx, byte ly)
     {
         m.WriteU8(buf + 0, present ? Connected    : Disconnected);
-        m.WriteU8(buf + 1, present ? DigitalId    : Disconnected);
+        m.WriteU8(buf + 1, present ? (analog ? AnalogId : DigitalId) : Disconnected);
         m.WriteU8(buf + 2, (byte)(buttons & 0xFF));
         m.WriteU8(buf + 3, (byte)(buttons >> 8));
         m.WriteU8(buf + 4, present ? rx : (byte)0x80);


### PR DESCRIPTION
## Summary

- Keep the CD stream LBA synchronized with the emulated drive position and pace `ReadS` at the physical sector rate.
- Load callback-driven sectors before delivery, handle zero-word sector requests, expose the CD poll hook, and complete reads cleanly.
- Implement pad mode and actuator queries while reporting DualShock analog IDs and state.

## Why

Ape Escape relies on `ReadS`/`GetlocP` timing, sector callback ordering, and DualShock mode/actuator responses. The existing stubs can let XA/STR streams outrun drive timing and prevent analog input discovery.

## Validation

- `dotnet build RecompOne.sln -c Release`
- Build succeeds with 0 errors (three existing warnings).
