### PR TITLE
Make the host window and ImGui UI DPI-aware

### DIFF
--- a/RecompOne.Runtime/Host/Window/HostWindow.cs
+++ b/RecompOne.Runtime/Host/Window/HostWindow.cs
@@ -35,6 +35,7 @@ public static class HostWindow
     static bool _layoutPending = true;
     static bool _closed;
     static DiscPickerPopup? _discPicker;
+    static float _dpiScale = 1f;
 
     public static void Initialize(string title)
     {
@@ -64,6 +65,8 @@ public static class HostWindow
             _headless = true;
         }
     }
+
+    public static float DpiScale => _dpiScale;
 
     public static string Title
     {
@@ -223,6 +226,24 @@ public static class HostWindow
         if (on) SetAutoIconify(false);
     }
 
+    static unsafe float QueryDpiScale()
+    {
+        try
+        {
+            var glfw = Silk.NET.GLFW.Glfw.GetApi();
+            var monitor = glfw.GetPrimaryMonitor();
+            if (monitor == null) return 1f;
+            glfw.GetMonitorContentScale(monitor, out float x, out float y);
+            float s = Math.Max(x, y);
+            return s > 0.1f ? s : 1f;
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"[Host] dpi scale query unavailable: {e.Message}");
+            return 1f;
+        }
+    }
+
     static unsafe void SetAutoIconify(bool on)
     {
         try
@@ -270,6 +291,14 @@ public static class HostWindow
 
     static void OnLoad()
     {
+        _dpiScale = QueryDpiScale();
+        if (_dpiScale > 1.01f && _window!.WindowState != WindowState.Fullscreen)
+        {
+            var scaled = new Vector2D<int>((int)(1280 * _dpiScale), (int)(720 * _dpiScale));
+            _window!.Size = scaled;
+            Console.WriteLine($"[Host] monitor content scale {_dpiScale:0.00}, resizing window to {scaled.X}x{scaled.Y}");
+        }
+
         var input = _window!.CreateInput();
         InputManager.Initialize(input);
 
@@ -328,10 +357,11 @@ public static class HostWindow
         var io = ImGui.GetIO();
         io.ConfigFlags |= ImGuiConfigFlags.DockingEnable;
         io.ConfigWindowsMoveFromTitleBarOnly = true;
-        io.FontGlobalScale = Config.ConfigManager.View.UiScale;
+        io.FontGlobalScale = Config.ConfigManager.View.UiScale * _dpiScale;
+        ImGui.GetStyle().ScaleAllSizes(_dpiScale);
         unsafe { io.NativePtr->IniFilename = null; }
 
-        Icons.Load(13f);
+        Icons.Load(13f * _dpiScale);
 
         if (Config.ConfigManager.ApplyImGuiLayout())
             _layoutPending = false;

--- a/RecompOne.Runtime/Host/Window/NoticePopup.cs
+++ b/RecompOne.Runtime/Host/Window/NoticePopup.cs
@@ -28,7 +28,7 @@ internal static class NoticePopup
 
         var vp = ImGui.GetMainViewport();
         ImGui.SetNextWindowPos(vp.GetCenter(), ImGuiCond.Appearing, new Vector2(0.5f, 0.5f));
-        ImGui.SetNextWindowSize(new Vector2(420, 0), ImGuiCond.Appearing);
+        ImGui.SetNextWindowSize(new Vector2(420 * HostWindow.DpiScale, 0), ImGuiCond.Appearing);
 
         bool open = _open;
         if (ImGui.BeginPopupModal(PopupId, ref open,
@@ -39,7 +39,7 @@ internal static class NoticePopup
             ImGui.Spacing();
             ImGui.Separator();
             ImGui.Spacing();
-            if (ImGui.Button("OK", new Vector2(120, 0)))
+            if (ImGui.Button("OK", new Vector2(120 * HostWindow.DpiScale, 0)))
             {
                 ImGui.CloseCurrentPopup();
                 _open = false;

--- a/RecompOne.Runtime/Host/Window/Panels/Configuration/DiscPickerPopup.cs
+++ b/RecompOne.Runtime/Host/Window/Panels/Configuration/DiscPickerPopup.cs
@@ -41,7 +41,7 @@ internal sealed class DiscPickerPopup : IPanel
 
         var vp = ImGui.GetMainViewport();
         ImGui.SetNextWindowPos(vp.GetCenter(), ImGuiCond.Always, new Vector2(0.5f, 0.5f));
-        ImGui.SetNextWindowSize(new Vector2(520, 0), ImGuiCond.Always);
+        ImGui.SetNextWindowSize(new Vector2(520 * HostWindow.DpiScale, 0), ImGuiCond.Always);
 
         bool open = true;
         if (!ImGui.BeginPopupModal(PopupId, ref open,
@@ -60,7 +60,7 @@ internal sealed class DiscPickerPopup : IPanel
         ImGui.TextWrapped("Please provide the path to the game's disc file.");
         ImGui.Spacing();
 
-        float browseW = 80;
+        float browseW = 80 * HostWindow.DpiScale;
         float spacing = ImGui.GetStyle().ItemSpacing.X;
         ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X - browseW - spacing);
         ImGui.InputText("##discpath", _pathBuf, (uint)BufSize);
@@ -80,7 +80,7 @@ internal sealed class DiscPickerPopup : IPanel
         ImGui.Separator();
         ImGui.Spacing();
 
-        float btnW = 100;
+        float btnW = 100 * HostWindow.DpiScale;
         float total = btnW * 2 + spacing;
         ImGui.SetCursorPosX((ImGui.GetContentRegionAvail().X - total) * 0.5f + ImGui.GetStyle().WindowPadding.X);
 

--- a/RecompOne.Runtime/Host/Window/Panels/Debug/CdDebugPanel.cs
+++ b/RecompOne.Runtime/Host/Window/Panels/Debug/CdDebugPanel.cs
@@ -14,7 +14,7 @@ internal sealed class CdDebugPanel : IPanel
 
     public void Draw()
     {
-        ImGui.SetNextWindowSize(new Vector2(640, 420), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(640, 420) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open)) { IsOpen = open; ImGui.End(); return; }
 

--- a/RecompOne.Runtime/Host/Window/Panels/Debug/ConsolePanel.cs
+++ b/RecompOne.Runtime/Host/Window/Panels/Debug/ConsolePanel.cs
@@ -18,7 +18,7 @@ internal sealed class ConsolePanel : IPanel
 
     public void Draw()
     {
-        ImGui.SetNextWindowSize(new Vector2(720, 320), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(720, 320) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open, ImGuiWindowFlags.MenuBar)) { IsOpen = open; ImGui.End(); return; }
 
@@ -50,7 +50,7 @@ internal sealed class ConsolePanel : IPanel
 
         ImGui.Checkbox("Auto-scroll", ref _autoScroll);
 
-        ImGui.SetNextItemWidth(180);
+        ImGui.SetNextItemWidth(180 * HostWindow.DpiScale);
         ImGui.InputTextWithHint("##filter", "filter", ref _filter, 128);
 
         ImGui.EndMenuBar();

--- a/RecompOne.Runtime/Host/Window/Panels/Debug/CpuStatePanel.cs
+++ b/RecompOne.Runtime/Host/Window/Panels/Debug/CpuStatePanel.cs
@@ -21,7 +21,7 @@ internal sealed class CpuStatePanel : IPanel
 
     public void Draw()
     {
-        ImGui.SetNextWindowSize(new Vector2(320, 540), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(320, 540) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open))
         {

--- a/RecompOne.Runtime/Host/Window/Panels/Debug/MemoryEditorPanel.cs
+++ b/RecompOne.Runtime/Host/Window/Panels/Debug/MemoryEditorPanel.cs
@@ -39,7 +39,7 @@ internal sealed class MemoryEditorPanel : IPanel
 
     public void Draw()
     {
-        ImGui.SetNextWindowSize(new Vector2(640, 480), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(640, 480) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open)) { IsOpen = open; ImGui.End(); return; }
 
@@ -56,7 +56,7 @@ internal sealed class MemoryEditorPanel : IPanel
 
     void DrawToolbar()
     {
-        ImGui.SetNextItemWidth(160);
+        ImGui.SetNextItemWidth(160 * HostWindow.DpiScale);
         if (ImGui.InputText("##addr", ref _addrInput, 10,
             ImGuiInputTextFlags.CharsHexadecimal | ImGuiInputTextFlags.EnterReturnsTrue))
         {

--- a/RecompOne.Runtime/Host/Window/Panels/Debug/OutputPanel.cs
+++ b/RecompOne.Runtime/Host/Window/Panels/Debug/OutputPanel.cs
@@ -18,7 +18,7 @@ internal sealed class OutputPanel : IPanel
     //idea: in the future make this be able to draw images so you can have ornamented backgrounds
     public void Draw()
     {
-        ImGui.SetNextWindowSize(new Vector2(640, 480), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(640, 480) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         ImGui.PushStyleColor(ImGuiCol.WindowBg, new Vector4(0f, 0f, 0f, 1f));
 
         if (!ImGui.Begin(Name, ImGuiWindowFlags.NoCollapse))

--- a/RecompOne.Runtime/Host/Window/Panels/Debug/OverlayEventsPanel.cs
+++ b/RecompOne.Runtime/Host/Window/Panels/Debug/OverlayEventsPanel.cs
@@ -22,7 +22,7 @@ internal sealed class OverlayEventsPanel : IPanel
 
     public void Draw()
     {
-        ImGui.SetNextWindowSize(new Vector2(600, 340), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(600, 340) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open, ImGuiWindowFlags.MenuBar))
         {

--- a/RecompOne.Runtime/Host/Window/Panels/Debug/RamMapPanel.cs
+++ b/RecompOne.Runtime/Host/Window/Panels/Debug/RamMapPanel.cs
@@ -18,7 +18,7 @@ internal sealed class RamMapPanel : IPanel
     public void Draw()
     {
         var flags = ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.MenuBar;
-        ImGui.SetNextWindowSize(new Vector2(820, 300), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(820, 300) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
 
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open, flags)) { IsOpen = open; ImGui.End(); return; }

--- a/RecompOne.Runtime/Host/Window/Panels/Debug/SpuViewerPanel.cs
+++ b/RecompOne.Runtime/Host/Window/Panels/Debug/SpuViewerPanel.cs
@@ -15,7 +15,7 @@ internal sealed class SpuViewerPanel : IPanel
 
     public void Draw()
     {
-        ImGui.SetNextWindowSize(new Vector2(860, 520), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(860, 520) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open)) { IsOpen = open; ImGui.End(); return; }
 

--- a/RecompOne.Runtime/Host/Window/Panels/Debug/VramViewerPanel.cs
+++ b/RecompOne.Runtime/Host/Window/Panels/Debug/VramViewerPanel.cs
@@ -18,7 +18,7 @@ internal sealed class VramViewerPanel : IPanel
     public void Draw()
     {
         var flags = ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.MenuBar;
-        ImGui.SetNextWindowSize(new Vector2(800, 450), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(800, 450) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
 
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open, flags)) { IsOpen = open; ImGui.End(); return; }

--- a/RecompOne.Runtime/Host/Window/Panels/Mods/ModLoadingPopup.cs
+++ b/RecompOne.Runtime/Host/Window/Panels/Mods/ModLoadingPopup.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using ImGuiNET;
+using RecompOne.Runtime.Host;
 
 namespace RecompOne.Runtime.Modding;
 
@@ -30,7 +31,7 @@ internal static class ModLoadingPopup
         if (!_active) return;
         var viewport = ImGui.GetMainViewport();
         ImGui.SetNextWindowPos(viewport.GetCenter(), ImGuiCond.Always, new Vector2(0.5f, 0.5f));
-        ImGui.SetNextWindowSize(new Vector2(380, 0), ImGuiCond.Always);
+        ImGui.SetNextWindowSize(new Vector2(380 * HostWindow.DpiScale, 0), ImGuiCond.Always);
         const ImGuiWindowFlags flags = ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoDocking | ImGuiWindowFlags.NoSavedSettings;
         if (ImGui.Begin("Loading mods", flags))
         {

--- a/RecompOne.Runtime/Host/Window/Panels/Mods/ModsPopup.cs
+++ b/RecompOne.Runtime/Host/Window/Panels/Mods/ModsPopup.cs
@@ -25,7 +25,7 @@ internal sealed class ModsPopup : IPanel
     public void Draw()
     {
         var vp = ImGui.GetMainViewport();
-        ImGui.SetNextWindowSize(new Vector2(560, 520), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(560, 520) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         ImGui.SetNextWindowPos(vp.GetCenter(), ImGuiCond.FirstUseEver, new Vector2(0.5f, 0.5f));
 
         bool open = IsOpen;

--- a/RecompOne.Runtime/Host/Window/Settings/Sections/PathsSettingsSection.cs
+++ b/RecompOne.Runtime/Host/Window/Settings/Sections/PathsSettingsSection.cs
@@ -71,7 +71,7 @@ internal sealed class PathsSettingsSection : ISettingsSection
     {
         result = "";
 
-        float browse = 80;
+        float browse = 80 * HostWindow.DpiScale;
         float spacing = ImGui.GetStyle().ItemSpacing.X;
         ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X - browse - spacing);
 

--- a/RecompOne.Runtime/Host/Window/Settings/SettingsPopup.cs
+++ b/RecompOne.Runtime/Host/Window/Settings/SettingsPopup.cs
@@ -14,7 +14,7 @@ internal sealed class SettingsPopup : IPanel
     public void Draw()
     {
         var vp = ImGui.GetMainViewport();
-        ImGui.SetNextWindowSize(new Vector2(760, 470), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(760, 470) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         ImGui.SetNextWindowPos(vp.GetCenter(), ImGuiCond.FirstUseEver, new Vector2(0.5f, 0.5f));
 
         bool open = IsOpen;
@@ -48,7 +48,7 @@ internal sealed class SettingsPopup : IPanel
 
     void DrawSidebar(IReadOnlyList<ISettingsSection> sections, ISettingsSection? current)
     {
-        ImGui.BeginChild("##settings-sidebar", new Vector2(SidebarWidth, 0), ImGuiChildFlags.Border);
+        ImGui.BeginChild("##settings-sidebar", new Vector2(SidebarWidth * HostWindow.DpiScale, 0), ImGuiChildFlags.Border);
 
         ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyle().Colors[(int)ImGuiCol.TextDisabled]);
         ImGui.TextUnformatted("SETTINGS");

--- a/RecompOne.Runtime/Host/Window/StartupNotice.cs
+++ b/RecompOne.Runtime/Host/Window/StartupNotice.cs
@@ -26,7 +26,7 @@ internal static class StartupNotice
 
         var vp = ImGui.GetMainViewport();
         ImGui.SetNextWindowPos(vp.GetCenter(), ImGuiCond.Always, new Vector2(0.5f, 0.5f));
-        ImGui.SetNextWindowSize(new Vector2(460, 0), ImGuiCond.Always);
+        ImGui.SetNextWindowSize(new Vector2(460 * HostWindow.DpiScale, 0), ImGuiCond.Always);
 
         if (ImGui.Begin(_title, ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove |
                 ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoDocking |


### PR DESCRIPTION
## Summary

On high-DPI monitors the window and every ImGui panel opened at a hardcoded
1280x720 with no regard for the display's actual scale factor, so at high
scaling (tested at 225%) the window and every popup/panel rendered tiny and
often unreadable, with several buttons clipping their own label text since
button widths were separate hardcoded pixel literals that didn't scale
alongside the font.

This is the base of a 4-repo/PR fix:

- This PR — adds `HostWindow.DpiScale` and fixes the host window/ImGui
  scaling itself.
- #9 — stacked on this one, swaps ImGui's blurry `FontGlobalScale`-stretched
  default font for a real embedded Inter font baked at the correct pixel
  size, so text is sharp instead of just correctly-sized.
- BlackLabelHQ/ShaderMod#1 — scales the shader mod's combo box width using
  `HostWindow.DpiScale` from this PR.
- BlackLabelHQ/SymphonyRecomp#66 — scales every other hardcoded UI size
  in the main repo (cheats, tracker/map overlays, randomizer, QoL, about,
  disc validator, auto-updater) using `HostWindow.DpiScale` from this PR.

**Merge order:** the other PRs reference `HostWindow.DpiScale` directly,
so they won't compile until this one is merged and their respective
submodule pointers (`RecompOne` in SymphonyRecomp, `mods` in the shaders
chain) get bumped to include it. This one's self-contained and can go in
on its own.

## Changes

- `HostWindow`: query the primary monitor's content scale via GLFW on load,
  resize the window to match, and scale ImGui's font (`FontGlobalScale`) and
  style (`ScaleAllSizes`) by the same factor. Skipped when already in
  fullscreen. Exposes `HostWindow.DpiScale` for panels to use.
- Every panel/popup with a hardcoded `Vector2` window size, button size, or
  `SetNextItemWidth` call now multiplies by `HostWindow.DpiScale` (debug
  panels, settings, mods popup, disc picker, notices).
- No-op at 100% scale, so this doesn't change anything for users on
  standard displays.

## Test plan

- [x] Built and ran at 225% Windows scaling — window now opens at a legible
      size and all previously-clipped button text (Confirm/Cancel/Browse,
      OK, etc.) renders fully
- [x] Confirmed behavior is unchanged at 100% scale (multiplying by 1 is a
      no-op)